### PR TITLE
Fix demo according to the latest changes in Clap

### DIFF
--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -12,7 +12,7 @@ ctrlc = "3.1"
 ecal = { path="../" }
 prost = "0.7"
 log = "0.4"
-clap = "3.0.0-beta.2"
+clap = { version = "3.0.0-beta.2", features = ["derive"] }
 
 [build-dependencies]
 prost-build = "0.6.1"

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::Clap;
+use clap::Parser;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -11,7 +11,7 @@ mod ecal_rs;
 type Publisher<T> = ecal::prost::Publisher<T>;
 type Subscriber<T> = ecal::prost::Subscriber<T>;
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Opts {
     #[clap(long)]
     pong: bool,


### PR DESCRIPTION
Without this `cargo build` fails with the following errors:

```
error[E0432]: unresolved import `clap::Clap`
 --> demo/src/main.rs:2:5
  |
2 | use clap::Clap;
  |     ^^^^^^^^^^ no `Clap` in the root

error: cannot determine resolution for the derive macro `Clap`
  --> demo/src/main.rs:14:10
   |
14 | #[derive(Clap)]
   |          ^^^^
   |
   = note: import resolution is stuck, try simplifying macro imports

error: cannot find attribute `clap` in this scope
  --> demo/src/main.rs:16:7
   |
16 |     #[clap(long)]
   |       ^^^^
   |
   = note: `clap` is in scope, but it is a crate, not an attribute

error[E0599]: no function or associated item named `parse` found for struct `Opts` in the current scope
  --> demo/src/main.rs:89:22
   |
15 | struct Opts {
   |        ---- function or associated item `parse` not found for this struct
...
89 |     let opts = Opts::parse();
   |                      ^^^^^ function or associated item not found in `Opts`
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following traits define an item `parse`, perhaps you need to implement one of them:
           candidate #1: `Parser`
           candidate #2: `TypedValueParser`

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `ecal_ping_demo` due to 4 previous errors
```